### PR TITLE
Add Launchd deployment docs for macOS

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -190,6 +190,40 @@ server {
 }
 ```
 
+### Option 4: Launchd on macOS
+
+For macOS environments, you can run the backend (and optional frontend) using Launchd. Complete the [macOS setup](README.md#macos-setup) first.
+
+#### Backend Plist
+1. **Create the plist** (e.g., `~/Library/LaunchAgents/com.o2filesearch.backend.plist`):
+   ```xml
+   <?xml version="1.0" encoding="UTF-8"?>
+   <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+   <plist version="1.0">
+   <dict>
+       <key>Label</key><string>com.o2filesearch.backend</string>
+       <key>WorkingDirectory</key><string>/path/to/O2FileSearchPlus/backend</string>
+       <key>ProgramArguments</key>
+       <array>
+           <string>/usr/local/bin/python3</string>
+           <string>main.py</string>
+       </array>
+       <key>RunAtLoad</key><true/>
+       <key>StandardOutPath</key><string>/tmp/o2_backend.log</string>
+       <key>StandardErrorPath</key><string>/tmp/o2_backend.err</string>
+   </dict>
+   </plist>
+   ```
+
+2. **Load and unload**:
+   ```bash
+   launchctl load ~/Library/LaunchAgents/com.o2filesearch.backend.plist
+   launchctl unload ~/Library/LaunchAgents/com.o2filesearch.backend.plist
+   ```
+
+#### Frontend Plist (Optional)
+Create a similar plist that runs `npm start` in the `frontend` directory if you want the frontend managed by Launchd as well.
+
 ## 🔧 Configuration
 
 ### Environment Variables

--- a/README.md
+++ b/README.md
@@ -50,6 +50,24 @@ O2FileSearchPlus Enhanced is a powerful local file search and indexing tool with
 - Python 3.7+ and Pip
 - Node.js (v18.x or later recommended) and npm
 
+### macOS Setup
+
+Use [Homebrew](https://brew.sh/) to install the required runtimes on macOS:
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+brew install python@3.11 node
+```
+
+Verify the tools are available:
+
+```bash
+python3 --version
+node --version
+```
+
+Continue with the [Backend Setup](#2-backend-setup) and [Frontend Setup](#3-frontend-setup).
+
 ### 1. Clone the Repository
 
 First, clone the repository to your local machine:


### PR DESCRIPTION
## Summary
- outline Homebrew-based macOS setup in README
- document Launchd plist example and usage in deployment guide

## Testing
- `python -m pytest -q` *(no tests found)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6840616903608330b205b4ba2c94e43a