### PR TITLE
Remove outdated comments in backend imports

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI, HTTPException, BackgroundTasks, Query
-from contextlib import asynccontextmanager # Ensure this is imported
+from contextlib import asynccontextmanager
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
@@ -18,7 +18,6 @@ import mimetypes
 import chardet
 import asyncio
 import uuid
-# Removed duplicate: from contextlib import asynccontextmanager (already imported at the top)
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.jobstores.base import JobLookupError


### PR DESCRIPTION
## Summary
- clean up stray comments in `backend/main.py`

## Testing
- `pytest -q` *(no tests found)*
- `npm test` *(fails: Missing script "test")*
- `./setup.sh` *(fails: frontend build error)*

------
https://chatgpt.com/codex/tasks/task_e_68405ab90a688330a202c40ccc6431e7