### PR TITLE
Fix search query alias

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -493,7 +493,7 @@ class SearchEngine:
         cursor = conn.cursor()
         
         # Build the query
-        query_parts = ["SELECT * FROM files_metadata WHERE 1=1"]
+        query_parts = ["SELECT fm.* FROM files_metadata fm WHERE 1=1"]
         params = []
         
         # Extension filter


### PR DESCRIPTION
## Summary
- ensure search query uses `fm` alias in `SearchEngine.search_files`

## Testing
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68405aaf08388330bf1b795df2629a49